### PR TITLE
Handle missing start dates in trainee pairing

### DIFF
--- a/index.html
+++ b/index.html
@@ -745,8 +745,10 @@
         };
 
         const getTrainingDates = (startDateStr, duration) => {
+            const startDate = new Date(startDateStr + 'T00:00:00');
+            if (isNaN(startDate) || !duration || duration < 1) return [];
             let dates = [];
-            let currentDate = new Date(startDateStr + 'T00:00:00');
+            let currentDate = startDate;
             while (dates.length < duration) {
                 const dayOfWeek = currentDate.getDay();
                 if (dayOfWeek !== 0 && dayOfWeek !== 6) {

--- a/index.txt
+++ b/index.txt
@@ -662,8 +662,10 @@
         };
 
         const getTrainingDates = (startDateStr, duration) => {
+            const startDate = new Date(startDateStr + 'T00:00:00');
+            if (isNaN(startDate) || !duration || duration < 1) return [];
             let dates = [];
-            let currentDate = new Date(startDateStr + 'T00:00:00');
+            let currentDate = startDate;
             while (dates.length < duration) {
                 const dayOfWeek = currentDate.getDay();
                 if (dayOfWeek !== 0 && dayOfWeek !== 6) {


### PR DESCRIPTION
## Summary
- Guard against missing or invalid start dates when generating training dates

## Testing
- `node <<'NODE'
const getTrainingDates=(s,d)=>{const startDate=new Date(s+'T00:00:00');if(isNaN(startDate)||!d||d<1)return[];let dates=[],currentDate=startDate;while(dates.length<d){const day=currentDate.getDay();if(day!==0&&day!==6){dates.push(new Date(currentDate));}currentDate.setDate(currentDate.getDate()+1);}return dates;};
console.log('valid',getTrainingDates('2024-06-03',5).map(d=>d.toISOString().slice(0,10)));
console.log('invalid',getTrainingDates('',5));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b73d51d32c83309b14c4e42da2bb29