### PR TITLE
Populate pairing editor when configuring trainees

### DIFF
--- a/index.html
+++ b/index.html
@@ -927,6 +927,7 @@
             document.querySelectorAll('.configure-pairing-btn').forEach(btn => {
                 btn.addEventListener('click', () => {
                     currentStep = 3;
+                    populatePairingUI();
                     updateGuideUI();
                     const pairingId = btn.dataset.pairingId;
                     const element = document.querySelector(`.pairing-entry[data-trainee-id="${pairingId}"]`);


### PR DESCRIPTION
## Summary
- Rebuild pairing editor UI when configuring a trainee from the dashboard

## Testing
- `npx -y prettier --check index.html` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68b73f9ab6c8833098e23448f91829a3